### PR TITLE
DODO-1169 Add operations that were not considered by doctolib/rubocop

### DIFF
--- a/lib/rubocop/cop/doctolib/one_operation_per_migration.rb
+++ b/lib/rubocop/cop/doctolib/one_operation_per_migration.rb
@@ -24,30 +24,49 @@ module RuboCop
 
         # From: https://api.rubyonrails.org/classes/ActiveRecord/Migration.html
         def_node_matcher(:migration_symbol?, <<~PATTERN)
-          {
-            :create_join_table
-            :create_table
+           {
+            :add_check_constraint
             :add_column
+            :add_columns
             :add_foreign_key
             :add_index
+            :add_index
+            :add_index_options
             :add_reference
             :add_timestamps
             :change_column
+            :change_column_comment
             :change_column_default
             :change_column_null
             :change_table
-            :rename_column
-            :rename_index
-            :rename_table
-            :drop_table
+            :change_table_comment
+            :check_constraints
+            :create_join_table
+            :create_table
+            :disable_extension
             :drop_join_table
+            :drop_schema
+            :drop_table
+            :enable_extension
+            :execute
+            :execute_block
+            :remove_check_constraint
             :remove_column
             :remove_columns
             :remove_foreign_key
             :remove_index
             :remove_reference
             :remove_timestamps
-            :execute
+            :rename_column
+            :rename_index
+            :rename_table
+            :reset_pk_sequence!
+            :set_pk_sequence!
+            :transaction
+            :update_table_definition
+            :validate_check_constraint
+            :validate_constraint
+            :validate_foreign_key
           }
         PATTERN
 

--- a/lib/rubocop/cop/doctolib/one_operation_per_migration.rb
+++ b/lib/rubocop/cop/doctolib/one_operation_per_migration.rb
@@ -58,8 +58,6 @@ module RuboCop
             :rename_column
             :rename_index
             :rename_table
-            :reset_pk_sequence!
-            :set_pk_sequence!
             :update_table_definition
             :validate_check_constraint
             :validate_constraint

--- a/lib/rubocop/cop/doctolib/one_operation_per_migration.rb
+++ b/lib/rubocop/cop/doctolib/one_operation_per_migration.rb
@@ -24,12 +24,11 @@ module RuboCop
 
         # From: https://api.rubyonrails.org/classes/ActiveRecord/Migration.html
         def_node_matcher(:migration_symbol?, <<~PATTERN)
-           {
+          {
             :add_check_constraint
             :add_column
             :add_columns
             :add_foreign_key
-            :add_index
             :add_index
             :add_index_options
             :add_reference
@@ -45,7 +44,6 @@ module RuboCop
             :create_table
             :disable_extension
             :drop_join_table
-            :drop_schema
             :drop_table
             :enable_extension
             :execute
@@ -62,7 +60,6 @@ module RuboCop
             :rename_table
             :reset_pk_sequence!
             :set_pk_sequence!
-            :transaction
             :update_table_definition
             :validate_check_constraint
             :validate_constraint


### PR DESCRIPTION
### 🧭 Context <img align="right" width="100" alt="dodo" src="https://github.com/doctolib/doctolib/raw/master/.github/TEAM_LOGO/dodo.png">

Some operation are not considered by the rules in `one_operation_per_migration.rb`.

### ✍️ Changes

We Identified these missing rules and added them to the list of operations in the pattern of the rubocop rule.
